### PR TITLE
Fix README typos on build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The page will be loaded with a fake domains list from `BrowserStorageSyncMock.ts
 
 ## Build
 ```js
-$ yarn buil:firefox   // The package will be built in the "build/firefox" directory.
-$ yarn buil:chrome    // The package will be built in the "build/chrome" directory.
+$ yarn build:firefox   // The package will be built in the "build/firefox" directory.
+$ yarn build:chrome    // The package will be built in the "build/chrome" directory.
 ```
 
 


### PR DESCRIPTION
This PR replace `buil` with `build` as this is the right command to run.