### PR TITLE
feat: add options_ui

### DIFF
--- a/public/manifests/chrome.json
+++ b/public/manifests/chrome.json
@@ -19,6 +19,12 @@
       "38": "images/hohser-38.png"
     }
   },
+  
+  "options_ui": {
+    "page": "popup.html",
+    "open_in_tab": true,
+    "chrome_style": false
+  },
 
   "permissions": ["storage", "tabs"],
 

--- a/public/manifests/firefox.json
+++ b/public/manifests/firefox.json
@@ -25,6 +25,12 @@
       "38": "images/hohser-38.png"
     }
   },
+  
+  "options_ui": {
+    "page": "popup.html",
+    "open_in_tab": true,
+    "browser_style": false
+  },
 
   "permissions": ["storage", "tabs"],
 


### PR DESCRIPTION
Sometimes I want to open the panel in a new tab so that it won't be closed automatically. Technically I could just type the browser action url and open it. This PR adds a little shortcut to the page via a options button.