### PR TITLE
Change to work properly on some Android browsers about Google search mobile

### DIFF
--- a/src/config/google.ts
+++ b/src/config/google.ts
@@ -2,7 +2,7 @@ import { SearchEngineConfig } from '../types';
 
 export const google: SearchEngineConfig = {
   resultSelector: '.g, .mnr-c, .rg_bx, .rg_di, .rg_el, .ZINbbc, .JP1Bwd, .isv-r',
-  domainSelector: '.TbwUpd, .dTe0Ie, .xQ82C, .e8fRJf, .FnqxG, .UPmit, .pDavDe, .fxgdke',
+  domainSelector: '.TbwUpd, .dTe0Ie, .xQ82C, .e8fRJf, .FnqxG, .UPmit, .gBIQub, .pDavDe, .fxgdke',
   observerSelector: '#rcnt, #cnt, #rg, #main',
   resultUrlSelector: '.r > a'
 };

--- a/src/config/google.ts
+++ b/src/config/google.ts
@@ -2,7 +2,7 @@ import { SearchEngineConfig } from '../types';
 
 export const google: SearchEngineConfig = {
   resultSelector: '.g, .mnr-c, .rg_bx, .rg_di, .rg_el, .ZINbbc, .JP1Bwd, .isv-r',
-  domainSelector: '.TbwUpd, .dTe0Ie, .xQ82C, .e8fRJf, .FnqxG, .BNeawe, .pDavDe, .fxgdke',
+  domainSelector: '.TbwUpd, .dTe0Ie, .xQ82C, .e8fRJf, .FnqxG, .UPmit, .pDavDe, .fxgdke',
   observerSelector: '#rcnt, #cnt, #rg, #main',
   resultUrlSelector: '.r > a'
 };


### PR DESCRIPTION
After fixed,
I confirmed the operation about Google search.

## Chromium with changed User-Agent on Linux

### Firefox on Android
User-Agent : Mozilla/5.0 (Android 7.0; Mobile; rv:62.0) Gecko/62.0 Firefox/62.0
- ALL ✓
- IMAGE ✓
- MOVIE ✓
- NEWS × Filtering using page title

### Kiwi Browser
User-Agent : Mozilla/5.0 (Linux; Android 9; Unspecified Device) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
- ALL ✓
- IMAGE ✓
- MOVIE ×
- NEWS ×

### Kiwi Browser on hardware
Same behavior
### Fennec F-Droid on hardware
Same behavior