### PR TITLE
feat: add new google shopping and google search ads selectors to google config

### DIFF
--- a/src/config/google.ts
+++ b/src/config/google.ts
@@ -1,8 +1,8 @@
 import { SearchEngineConfig } from '../types';
 
 export const google: SearchEngineConfig = {
-  resultSelector: '.g, .mnr-c, .rg_bx, .rg_di, .rg_el, .ZINbbc, .JP1Bwd, .isv-r',
-  domainSelector: '.TbwUpd, .dTe0Ie, .xQ82C, .e8fRJf, .FnqxG, .UPmit, .gBIQub, .pDavDe, .fxgdke',
+  resultSelector: '.g, .mnr-c, .rg_bx, .rg_di, .rg_el, .ZINbbc, .JP1Bwd, .isv-r, .cUezCb, .KZmu8e, .EQ4p8c, .sh-dlr__list-result',
+  domainSelector: '.TbwUpd, .dTe0Ie, .xQ82C, .e8fRJf, .FnqxG, .UPmit, .gBIQub, .pDavDe, .fxgdke, .fxYMc, .IHk3ob, .E5ocAb, .lg3aE',
   observerSelector: '#rcnt, #cnt, #rg, #main',
   resultUrlSelector: '.r > a'
 };


### PR DESCRIPTION
-You can add words or site name for Google Shopping page.
-Domains can use for google search ads