### PR TITLE
Update window load event listener

### DIFF
--- a/src/content.tsx
+++ b/src/content.tsx
@@ -230,10 +230,12 @@ browserStorageSync.get('options')
     // Initial process results
     processResults(domainList, options);
 
-    // Process results on page load
-    document.addEventListener('load', () => {
-      processResults(domainList, options);
-    });
+    // Re-process results on page load if it wasn't done initially
+    if (document.readyState !== 'complete') {
+      window.addEventListener('load', () => {
+        processResults(domainList, options);
+      });
+    }
 
     // Process results on DOM change
     const targets = document.querySelectorAll(searchEngineConfig.observerSelector);


### PR DESCRIPTION
In content.tsx, the results are supposed to be re-processed after all content has finished loading, but the event listener is incorrect -- the 'load' event fires for the window object rather than document. It also only fires if the page content hasn't already loaded by the time the domain list is retrieved.
I've changed the event listener to be attached to the window and object and wrapped it in a `document.readyState` check as recommended by <https://stackoverflow.com/questions/43233115/chrome-content-scripts-arent-working-domcontentloaded-listener-does-not-execut>