### PR TITLE
Support Firefox for Android

### DIFF
--- a/public/manifests/firefox.json
+++ b/public/manifests/firefox.json
@@ -266,6 +266,9 @@
     "gecko": {
       "id": "{2d0ade95-bf3c-4868-b877-71ccd038e11b}",
       "strict_min_version": "79.0"
+    },
+    "gecko_android": {
+      "strict_min_version": "113.0"
     }
   },
   "commands": {


### PR DESCRIPTION
According to MDN,

> To support Firefox for Android without specifying a version range, the gecko_android sub-key must be an empty object, i.e., "gecko_android": {}. Otherwise, the extension is only made available on desktop Firefox.

which means adding this property should mark the extension as available for Android.

113.0 is the first version that "introduced support for browser_specific_settings.gecko_android" according to web-ext lint. If this was not set, web-ext lint complains that

> "strict_min_version" requires Firefox for Android 79, which was released before version 113 introduced support for "browser_specific_settings.gecko_android".

I've tested lightly on Android. The only issue is that the dropdown requires a long press to trigger a hover, otherwise the hiding and highlighting works just as expected. Thanks to MUI the popup page also works really well on a touchscreen.